### PR TITLE
Introduce EventStore and refactor game handling

### DIFF
--- a/SportsBuddyFinder/SportsBuddyFinder/ContentView.swift
+++ b/SportsBuddyFinder/SportsBuddyFinder/ContentView.swift
@@ -10,11 +10,13 @@ import FirebaseAuth
 
 struct ContentView: View {
     @State private var isLoggedIn = Auth.auth().currentUser != nil
+    @StateObject private var eventStore = EventStore()
 
     var body: some View {
         Group {
             if isLoggedIn {
                 MainTabView(isLoggedIn: $isLoggedIn)
+                    .environmentObject(eventStore)
             } else {
                 LoginView(isLoggedIn: $isLoggedIn)
             }

--- a/SportsBuddyFinder/SportsBuddyFinder/GameService.swift
+++ b/SportsBuddyFinder/SportsBuddyFinder/GameService.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import SwiftUI
 import FirebaseAuth
 import FirebaseFirestore
 import CoreLocation
@@ -19,6 +20,41 @@ final class GameService {
 
     private var usersCollection: CollectionReference {
         db.collection("users")
+    }
+
+    private func appError(_ message: String, code: Int = 0) -> Error {
+        NSError(domain: "GameService", code: code, userInfo: [
+            NSLocalizedDescriptionKey: message
+        ])
+    }
+
+    private func mapFirestoreError(_ error: Error, fallback: String) -> Error {
+        let nsError = error as NSError
+
+        if nsError.domain == FirestoreErrorDomain,
+           nsError.code == FirestoreErrorCode.permissionDenied.rawValue {
+            return appError(
+                "Firestore denied this action. Update your Firestore rules to allow signed-in users to create and join games.",
+                code: nsError.code
+            )
+        }
+
+        let message = error.localizedDescription.trimmingCharacters(in: .whitespacesAndNewlines)
+        return appError(message.isEmpty ? fallback : message, code: nsError.code)
+    }
+
+    func observeGames(onChange: @escaping (Result<[SportsEvent], Error>) -> Void) -> ListenerRegistration {
+        db.collection("games")
+            .order(by: "gameDate", descending: false)
+            .addSnapshotListener { snapshot, error in
+                if let error = error {
+                    onChange(.failure(self.mapFirestoreError(error, fallback: "Unable to load games.")))
+                    return
+                }
+
+                let events = snapshot?.documents.map(self.makeSportsEvent(from:)) ?? []
+                onChange(.success(events))
+            }
     }
 
     func createGame(
@@ -52,7 +88,14 @@ final class GameService {
             "createdAt": Timestamp(date: Date())
         ]
 
-        db.collection("games").addDocument(data: data, completion: completion)
+        db.collection("games").addDocument(data: data) { error in
+            if let error {
+                completion(self.mapFirestoreError(error, fallback: "Unable to create game."))
+                return
+            }
+
+            completion(nil)
+        }
     }
 
     func fetchGames(completion: @escaping (Result<[SportsEvent], Error>) -> Void) {
@@ -60,41 +103,11 @@ final class GameService {
             .order(by: "gameDate", descending: false)
             .getDocuments { snapshot, error in
                 if let error = error {
-                    completion(.failure(error))
+                    completion(.failure(self.mapFirestoreError(error, fallback: "Unable to load games.")))
                     return
                 }
 
-                let events: [SportsEvent] = snapshot?.documents.compactMap { doc in
-                    let data = doc.data()
-
-                    let title = data["title"] as? String ?? "Untitled Game"
-                    let sport = data["sport"] as? String ?? "Unknown Sport"
-                    let locationName = data["locationName"] as? String ?? "Unknown Location"
-                    let skillLevel = data["skillLevel"] as? String ?? "All Levels"
-                    let spotsLeft = data["spotsLeft"] as? Int ?? 0
-                    let latitude = data["latitude"] as? Double ?? 36.6522
-                    let longitude = data["longitude"] as? Double ?? -121.7989
-
-                    let timestamp = data["gameDate"] as? Timestamp ?? Timestamp(date: Date())
-                    let date = timestamp.dateValue()
-
-                    let formatter = DateFormatter()
-                    formatter.dateStyle = .medium
-                    formatter.timeStyle = .short
-                    let formattedDate = formatter.string(from: date)
-
-                    return SportsEvent(
-                        id: doc.documentID,
-                        title: title,
-                        sport: sport,
-                        time: formattedDate,
-                        locationName: locationName,
-                        skillLevel: skillLevel,
-                        spotsLeft: spotsLeft,
-                        coordinate: CLLocationCoordinate2D(latitude: latitude, longitude: longitude),
-                        hostUid: data["hostUid"] as? String
-                    )
-                } ?? []
+                let events = snapshot?.documents.map(self.makeSportsEvent(from:)) ?? []
 
                 completion(.success(events))
             }
@@ -111,7 +124,7 @@ final class GameService {
             .collection("joinedGames")
             .getDocuments { snapshot, error in
                 if let error = error {
-                    completion(.failure(error))
+                    completion(.failure(self.mapFirestoreError(error, fallback: "Unable to load joined games.")))
                     return
                 }
 
@@ -185,7 +198,129 @@ final class GameService {
 
             return nil
         }) { _, error in
-            completion(error)
+            if let error {
+                completion(self.mapFirestoreError(error, fallback: "Unable to join this game."))
+                return
+            }
+
+            completion(nil)
+        }
+    }
+
+    private func makeSportsEvent(from doc: QueryDocumentSnapshot) -> SportsEvent {
+        let data = doc.data()
+
+        let title = data["title"] as? String ?? "Untitled Game"
+        let sport = data["sport"] as? String ?? "Unknown Sport"
+        let locationName = data["locationName"] as? String ?? "Unknown Location"
+        let skillLevel = data["skillLevel"] as? String ?? "All Levels"
+        let spotsLeft = data["spotsLeft"] as? Int ?? 0
+        let latitude = data["latitude"] as? Double ?? 36.6522
+        let longitude = data["longitude"] as? Double ?? -121.7989
+
+        let timestamp = data["gameDate"] as? Timestamp ?? Timestamp(date: Date())
+        let date = timestamp.dateValue()
+
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .short
+
+        return SportsEvent(
+            id: doc.documentID,
+            title: title,
+            sport: sport,
+            time: formatter.string(from: date),
+            locationName: locationName,
+            skillLevel: skillLevel,
+            spotsLeft: spotsLeft,
+            coordinate: CLLocationCoordinate2D(latitude: latitude, longitude: longitude),
+            hostUid: data["hostUid"] as? String
+        )
+    }
+}
+
+@MainActor
+final class EventStore: ObservableObject {
+    @Published var events: [SportsEvent] = []
+    @Published var joinedGameIDs: Set<String> = []
+    @Published var message = ""
+
+    private let gameService: GameService
+    private var gamesListener: ListenerRegistration?
+
+    init(gameService: GameService = .shared) {
+        self.gameService = gameService
+        start()
+    }
+
+    deinit {
+        gamesListener?.remove()
+    }
+
+    func start() {
+        if gamesListener == nil {
+            gamesListener = gameService.observeGames { [weak self] result in
+                Task { @MainActor in
+                    switch result {
+                    case .success(let events):
+                        self?.events = events
+                        if self?.message.contains("join") != true {
+                            self?.message = ""
+                        }
+                    case .failure(let error):
+                        self?.message = error.localizedDescription
+                    }
+                }
+            }
+        }
+
+        refreshJoinedGameIDs()
+    }
+
+    func refreshJoinedGameIDs() {
+        gameService.fetchJoinedGameIDs { [weak self] result in
+            Task { @MainActor in
+                switch result {
+                case .success(let ids):
+                    self?.joinedGameIDs = ids
+                case .failure(let error):
+                    self?.message = error.localizedDescription
+                }
+            }
+        }
+    }
+
+    func joinGame(_ event: SportsEvent, completion: ((Error?) -> Void)? = nil) {
+        gameService.joinGame(event: event) { [weak self] error in
+            Task { @MainActor in
+                if let error {
+                    self?.message = error.localizedDescription
+                    completion?(error)
+                    return
+                }
+
+                self?.joinedGameIDs.insert(event.id)
+                self?.events = self?.events.map { currentEvent in
+                    guard currentEvent.id == event.id else {
+                        return currentEvent
+                    }
+
+                    return SportsEvent(
+                        id: currentEvent.id,
+                        title: currentEvent.title,
+                        sport: currentEvent.sport,
+                        time: currentEvent.time,
+                        locationName: currentEvent.locationName,
+                        skillLevel: currentEvent.skillLevel,
+                        spotsLeft: max(currentEvent.spotsLeft - 1, 0),
+                        coordinate: currentEvent.coordinate,
+                        hostUid: currentEvent.hostUid
+                    )
+                } ?? []
+                self?.message = "You joined \(event.title)."
+                self?.refreshJoinedGameIDs()
+                completion?(nil)
+            }
         }
     }
 }

--- a/SportsBuddyFinder/SportsBuddyFinder/ListView.swift
+++ b/SportsBuddyFinder/SportsBuddyFinder/ListView.swift
@@ -9,10 +9,8 @@ import SwiftUI
 import FirebaseAuth
 
 struct ListView: View {
-    @State private var events: [SportsEvent] = []
-    @State private var joinedGameIDs: Set<String> = []
+    @EnvironmentObject private var eventStore: EventStore
     @State private var joiningGameIDs: Set<String> = []
-    @State private var message = ""
 
     var body: some View {
         NavigationStack {
@@ -32,18 +30,18 @@ struct ListView: View {
                             .foregroundColor(.white)
                             .padding(.top)
 
-                        if !message.isEmpty {
-                            Text(message)
+                        if !eventStore.message.isEmpty {
+                            Text(eventStore.message)
                                 .foregroundColor(.white)
                                 .font(.caption)
                         }
 
-                        if events.isEmpty {
+                        if eventStore.events.isEmpty {
                             Text("No games available yet.")
                                 .foregroundColor(.white.opacity(0.85))
                                 .padding(.top, 40)
                         } else {
-                            ForEach(events) { event in
+                            ForEach(eventStore.events) { event in
                                 eventRow(for: event)
                             }
                         }
@@ -53,40 +51,10 @@ struct ListView: View {
             }
             .navigationBarHidden(true)
             .onAppear {
-                loadData()
+                eventStore.start()
             }
             .refreshable {
-                loadData()
-            }
-        }
-    }
-
-    private func loadData() {
-        loadGames()
-        loadJoinedGames()
-    }
-
-    private func loadGames() {
-        GameService.shared.fetchGames { result in
-            switch result {
-            case .success(let loadedEvents):
-                events = loadedEvents
-                if !message.contains("join") {
-                    message = ""
-                }
-            case .failure(let error):
-                message = error.localizedDescription
-            }
-        }
-    }
-
-    private func loadJoinedGames() {
-        GameService.shared.fetchJoinedGameIDs { result in
-            switch result {
-            case .success(let ids):
-                joinedGameIDs = ids
-            case .failure(let error):
-                message = error.localizedDescription
+                eventStore.start()
             }
         }
     }
@@ -94,7 +62,7 @@ struct ListView: View {
     private func eventRow(for event: SportsEvent) -> some View {
         let currentUid = Auth.auth().currentUser?.uid
         let isHost = event.hostUid == currentUid
-        let isJoined = joinedGameIDs.contains(event.id)
+        let isJoined = eventStore.joinedGameIDs.contains(event.id)
         let isJoining = joiningGameIDs.contains(event.id)
         let canJoin = !isHost && !isJoined && !isJoining && event.spotsLeft > 0
 
@@ -179,37 +147,18 @@ struct ListView: View {
 
     private func joinGame(_ event: SportsEvent) {
         joiningGameIDs.insert(event.id)
-        message = ""
 
-        GameService.shared.joinGame(event: event) { error in
+        eventStore.message = ""
+        eventStore.joinGame(event) { error in
             joiningGameIDs.remove(event.id)
-
-            if let error = error {
-                message = error.localizedDescription
-                return
+            if let error {
+                eventStore.message = error.localizedDescription
             }
-
-            joinedGameIDs.insert(event.id)
-            if let index = events.firstIndex(where: { $0.id == event.id }) {
-                let updatedEvent = SportsEvent(
-                    id: events[index].id,
-                    title: events[index].title,
-                    sport: events[index].sport,
-                    time: events[index].time,
-                    locationName: events[index].locationName,
-                    skillLevel: events[index].skillLevel,
-                    spotsLeft: max(events[index].spotsLeft - 1, 0),
-                    coordinate: events[index].coordinate,
-                    hostUid: events[index].hostUid
-                )
-                events[index] = updatedEvent
-            }
-
-            message = "You joined \(event.title)."
         }
     }
 }
 
 #Preview {
     ListView()
+        .environmentObject(EventStore())
 }

--- a/SportsBuddyFinder/SportsBuddyFinder/MapView.swift
+++ b/SportsBuddyFinder/SportsBuddyFinder/MapView.swift
@@ -7,27 +7,24 @@
 
 import SwiftUI
 import MapKit
+import FirebaseAuth
 
 struct MapView: View {
+    @EnvironmentObject private var eventStore: EventStore
+
     @State private var region = MKCoordinateRegion(
         center: CLLocationCoordinate2D(latitude: 36.6522, longitude: -121.7989),
         span: MKCoordinateSpan(latitudeDelta: 0.012, longitudeDelta: 0.012)
     )
-
     @State private var selectedEvent: SportsEvent?
-    @State private var joinedEvents: Set<String> = []
-
-    let events = SportsEvent.sampleEvents
+    @State private var joiningEventIDs: Set<String> = []
 
     var body: some View {
         ZStack(alignment: .bottom) {
-            Map(coordinateRegion: $region, annotationItems: events) { event in
+            Map(coordinateRegion: $region, annotationItems: eventStore.events) { event in
                 MapAnnotation(coordinate: event.coordinate) {
                     Button {
-                        withAnimation(.spring()) {
-                            selectedEvent = event
-                            region.center = event.coordinate
-                        }
+                        focus(on: event)
                     } label: {
                         VStack(spacing: 4) {
                             Image(systemName: selectedEvent?.id == event.id ? "figure.run.circle.fill" : "mappin.circle.fill")
@@ -51,21 +48,28 @@ struct MapView: View {
             VStack(spacing: 12) {
                 headerView
 
-                ScrollView(.horizontal, showsIndicators: false) {
-                    HStack(spacing: 12) {
-                        ForEach(events) { event in
-                            Button {
-                                withAnimation(.spring()) {
-                                    selectedEvent = event
-                                    region.center = event.coordinate
+                if eventStore.events.isEmpty {
+                    Text("No games on the map yet.")
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+                        .padding()
+                        .background(.ultraThinMaterial)
+                        .cornerRadius(16)
+                        .padding(.horizontal)
+                } else {
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        HStack(spacing: 12) {
+                            ForEach(eventStore.events) { event in
+                                Button {
+                                    focus(on: event)
+                                } label: {
+                                    eventCard(for: event)
                                 }
-                            } label: {
-                                eventCard(for: event)
+                                .buttonStyle(.plain)
                             }
-                            .buttonStyle(.plain)
                         }
+                        .padding(.horizontal)
                     }
-                    .padding(.horizontal)
                 }
 
                 if let selectedEvent {
@@ -76,7 +80,11 @@ struct MapView: View {
             .padding(.bottom, 10)
         }
         .onAppear {
-            selectedEvent = events.first
+            eventStore.start()
+            syncSelection(with: eventStore.events)
+        }
+        .onChange(of: eventStore.events) { _, newEvents in
+            syncSelection(with: newEvents)
         }
     }
 
@@ -94,11 +102,8 @@ struct MapView: View {
             Spacer()
 
             Button {
-                withAnimation(.easeInOut) {
-                    selectedEvent = events.randomElement()
-                    if let selectedEvent {
-                        region.center = selectedEvent.coordinate
-                    }
+                if let randomEvent = eventStore.events.randomElement() {
+                    focus(on: randomEvent)
                 }
             } label: {
                 Image(systemName: "location.magnifyingglass")
@@ -107,6 +112,7 @@ struct MapView: View {
                     .background(.thinMaterial)
                     .clipShape(Circle())
             }
+            .disabled(eventStore.events.isEmpty)
         }
         .padding()
         .background(.ultraThinMaterial)
@@ -117,7 +123,7 @@ struct MapView: View {
 
     private func eventCard(for event: SportsEvent) -> some View {
         let isSelected = selectedEvent?.id == event.id
-        let isJoined = joinedEvents.contains(event.id)
+        let isJoined = eventStore.joinedGameIDs.contains(event.id)
 
         return VStack(alignment: .leading, spacing: 8) {
             HStack {
@@ -166,7 +172,11 @@ struct MapView: View {
     }
 
     private func selectedEventPanel(for event: SportsEvent) -> some View {
-        let isJoined = joinedEvents.contains(event.id)
+        let currentUid = Auth.auth().currentUser?.uid
+        let isHost = event.hostUid == currentUid
+        let isJoined = eventStore.joinedGameIDs.contains(event.id)
+        let isJoining = joiningEventIDs.contains(event.id)
+        let canJoin = !isHost && !isJoined && !isJoining && event.spotsLeft > 0
 
         return VStack(alignment: .leading, spacing: 14) {
             HStack {
@@ -199,51 +209,100 @@ struct MapView: View {
             }
             .foregroundColor(.secondary)
 
-            Text("This is a rough preview card for the selected event. Tapping map pins or cards updates this panel, and the join button just toggles local UI state for now.")
-                .font(.footnote)
-                .foregroundColor(.secondary)
+            if !eventStore.message.isEmpty {
+                Text(eventStore.message)
+                    .font(.footnote)
+                    .foregroundColor(.secondary)
+            }
 
             HStack(spacing: 12) {
                 Button {
-                    withAnimation(.spring()) {
-                        if joinedEvents.contains(event.id) {
-                            joinedEvents.remove(event.id)
-                        } else {
-                            joinedEvents.insert(event.id)
-                        }
-                    }
+                    joinEvent(event)
                 } label: {
-                    Text(isJoined ? "Joined" : "Attend Event")
+                    Text(joinButtonTitle(isHost: isHost, isJoined: isJoined, isJoining: isJoining, spotsLeft: event.spotsLeft))
                         .fontWeight(.semibold)
                         .frame(maxWidth: .infinity)
                         .padding(.vertical, 12)
-                        .background(isJoined ? Color.green : Color.orange)
+                        .background(canJoin ? Color.orange : Color.gray.opacity(0.35))
                         .foregroundColor(.white)
                         .cornerRadius(14)
                 }
+                .disabled(!canJoin)
 
                 Button {
                     withAnimation(.easeInOut) {
                         region.center = event.coordinate
-                        region.span = MKCoordinateSpan(latitudeDelta: 0.005, longitudeDelta: 0.005)
                     }
                 } label: {
                     Image(systemName: "scope")
                         .font(.title3)
                         .frame(width: 48, height: 48)
-                        .background(Color.black.opacity(0.08))
+                        .background(Color.blue.opacity(0.14))
                         .cornerRadius(14)
                 }
             }
         }
         .padding()
-        .background(.white)
+        .background(.thinMaterial)
         .cornerRadius(24)
-        .shadow(color: .black.opacity(0.12), radius: 10, x: 0, y: 4)
         .padding(.horizontal)
+    }
+
+    private func joinButtonTitle(isHost: Bool, isJoined: Bool, isJoining: Bool, spotsLeft: Int) -> String {
+        if isHost {
+            return "You Created This Game"
+        }
+
+        if isJoined {
+            return "Joined"
+        }
+
+        if isJoining {
+            return "Joining..."
+        }
+
+        if spotsLeft <= 0 {
+            return "Game Full"
+        }
+
+        return "Join Game"
+    }
+
+    private func joinEvent(_ event: SportsEvent) {
+        joiningEventIDs.insert(event.id)
+        eventStore.message = ""
+
+        eventStore.joinGame(event) { _ in
+            joiningEventIDs.remove(event.id)
+        }
+    }
+
+    private func focus(on event: SportsEvent) {
+        withAnimation(.spring()) {
+            selectedEvent = event
+            region.center = event.coordinate
+        }
+    }
+
+    private func syncSelection(with events: [SportsEvent]) {
+        guard !events.isEmpty else {
+            selectedEvent = nil
+            return
+        }
+
+        if let selectedEvent,
+           let refreshedSelection = events.first(where: { $0.id == selectedEvent.id }) {
+            self.selectedEvent = refreshedSelection
+            return
+        }
+
+        if let newestEvent = events.last {
+            focus(on: newestEvent)
+        }
     }
 }
 
 #Preview {
     MapView()
+        .environmentObject(EventStore())
 }


### PR DESCRIPTION
Add a centralized EventStore (ObservableObject @MainActor) to manage events, joined game IDs and user messages, and inject it into the app environment from ContentView. Refactor GameService to provide better error mapping, an observeGames listener, a makeSportsEvent helper, and safer completion handling for create/fetch/join operations. Update ListView and MapView to use the EventStore (environmentObject) and remove duplicated local loading/joining logic; adjust UI and join flows to reflect real-time data and improved state management. Overall change centralizes state, enables realtime updates via Firestore snapshot listener, and standardizes error messages.